### PR TITLE
tests: Make test platform-agnostic

### DIFF
--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -499,8 +499,8 @@ var _ = framework.KubeDescribe("Pods", func() {
 			Param("stderr", "1").
 			Param("stdout", "1").
 			Param("container", pod.Spec.Containers[0].Name).
-			Param("command", "cat").
-			Param("command", "/etc/resolv.conf")
+			Param("command", "echo").
+			Param("command", "remote execution test")
 
 		url := req.URL()
 		ws, err := framework.OpenWebSocketForURL(url, config, []string{"channel.k8s.io"})
@@ -536,8 +536,8 @@ var _ = framework.KubeDescribe("Pods", func() {
 			if buf.Len() == 0 {
 				return fmt.Errorf("Unexpected output from server")
 			}
-			if !strings.Contains(buf.String(), "nameserver") {
-				return fmt.Errorf("Expected to find 'nameserver' in %q", buf.String())
+			if !strings.Contains(buf.String(), "remote execution test") {
+				return fmt.Errorf("Expected to find 'remote execution test' in %q", buf.String())
 			}
 			return nil
 		}, time.Minute, 10*time.Second).Should(BeNil())


### PR DESCRIPTION
The test:
[k8s.io] Pods should support remote command execution over websockets [NodeConformance]

  used cat on /etc/resolv.conf and checked if the output contained "namespace",
which is incompatible with windows containers.

  now it will use echo "remote execution test" and check if the output contains
"remote execution test".
